### PR TITLE
1.0.0 beta for 0.5.5 hap-nodejs

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -108,8 +108,8 @@ Server.prototype._publish = function() {
   var bridgeConfig = this._config.bridge || {};
 
   var info = this._bridge.getService(Service.AccessoryInformation);
-  info.setCharacteristic(Characteristic.Manufacturer, `${toTitleCase(require('../package.json').author.name)}`);
-  info.setCharacteristic(Characteristic.Model, `${toTitleCase(require('../package.json').name)}`);
+  info.setCharacteristic(Characteristic.Manufacturer, bridgeConfig.manufacturer || `homebridge.io`);
+  info.setCharacteristic(Characteristic.Model, bridgeConfig.model || `homebridge`);
   info.setCharacteristic(Characteristic.SerialNumber, bridgeConfig.username);
   info.setCharacteristic(Characteristic.FirmwareRevision, require('../package.json').version);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge",
   "description": "HomeKit support for the impatient",
-  "version": "0.4.50",
+  "version": "1.0.0-beta1",
   "scripts": {
     "dev": "DEBUG=* ./bin/homebridge -D -P example-plugins/ || true"
   },


### PR DESCRIPTION
@Supereg to fix what was Implemented on [#2430](https://github.com/nfarina/homebridge/pull/2430) and to get 1.0.0-beta going.